### PR TITLE
add a test script that backdoors `ls`

### DIFF
--- a/test_script.sh
+++ b/test_script.sh
@@ -3,10 +3,6 @@
 # This script configures a simple local python webserver
 # and downloads $(which ls) from it through BDF proxy.
 
-#
-# IMPORTANT: set transparentProxy = False before running this test
-#
-
 # figure out python executable (especially relevant on arch linux)
 if [ $(which python2.7) ]
 then
@@ -25,23 +21,34 @@ $PYTHON -m SimpleHTTPServer 9001 &
 SERVER_PID=$!
 cd -
 
+echo "[*] Making a backup copy of config"
+cp bdfproxy.cfg bdfproxy.cfg.backup
+
+echo "[*] Patching config to turn off transparentProxy"
+sed -i 's/^transparentProxy.\+/transparentProxy = False/' bdfproxy.cfg
+
 # start the proxy
 echo "[*] Starting"
 $PYTHON ./bdf_proxy.py &
 sleep 5
 PROXY_PID=$!
 
-# try to backdoor ls
 echo "[*] Copying "$(which ls)" to /tmp"
 cp $(which ls) /tmp
+
+echo "[*] Attempting to download a backdoored version of "$(which ls)" to $(pwd)/ls_backdoored"
 curl 'http://localhost:9001/ls' --proxy1.0 localhost:8080 > ls_backdoored
-rm -f /tmp/ls
-chmod +x ls_backdoored
 
 echo "[*] Shutting down"
-
-# shut down the services
 kill $SERVER_PID
 kill $PROXY_PID
 
+echo "[*] Copying old config back"
+cp bdfproxy.cfg.backup bdfproxy.cfg
+
+echo "[*] Cleaning up temporary files"
+rm -f /tmp/ls
+rm bdfproxy.cfg.backup
+
 echo "[*] ls_backdoored is available for testing in" $(pwd)
+chmod +x ls_backdoored


### PR DESCRIPTION
I didn't use `which ls` because that doesn't actually work on my system and it might not work on others. I have a shell script that wraps ls and `which ls` returns the path to a shell script. That might be the case for others too, so I just used /bin/ls. Let me know if that's a problem on some systems.
