### PR TITLE
add support for OS integrated bdfproxy with OS-integrated bdf.

### DIFF
--- a/test_script.sh
+++ b/test_script.sh
@@ -22,14 +22,14 @@ SERVER_PID=$!
 cd -
 
 echo "[*] Making a backup copy of config"
-cp bdfproxy.cfg bdfproxy.cfg.backup
+cp /etc/bdfproxy/bdfproxy.cfg bdfproxy.cfg
 
 echo "[*] Patching config to turn off transparentProxy"
 sed -i 's/^transparentProxy.\+/transparentProxy = False/' bdfproxy.cfg
 
 # start the proxy
 echo "[*] Starting"
-$PYTHON ./bdf_proxy.py &
+$PYTHON /ur/bin/bdf_proxy &
 sleep 5
 PROXY_PID=$!
 
@@ -43,12 +43,9 @@ echo "[*] Shutting down"
 kill $SERVER_PID
 kill $PROXY_PID
 
-echo "[*] Copying old config back"
-cp bdfproxy.cfg.backup bdfproxy.cfg
-
 echo "[*] Cleaning up temporary files"
 rm -f /tmp/ls
-rm bdfproxy.cfg.backup
+rm bdfproxy.cfg
 
 echo "[*] ls_backdoored is available for testing in" $(pwd)
 chmod +x ls_backdoored


### PR DESCRIPTION
This release support newer version of mitmproxy 0.18 and higher) as distributed in Debian (and in Kali, as a consequence).
The config file can be installed in /etc/bdfproxy/bdfproxy.cfg but can be overloaded by the same file in the current dir, to allow the test files to continue to work (see the diff).
This implies that bdf has merged the PR secretsquirrel/the-backdoor-factory#81.

I'll push the patch in the Debian package to get a review from the Kali folks.
If you merge the patch upstream, i'll delete it from the Debian package and update the upstream version of both bdfproxy and backdoor-factory.

Cheers,